### PR TITLE
Bump finagle thrift, move org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Faraday::Zipkin
 
-[![Build Status](https://travis-ci.org/Oscil8/faraday-zipkin.svg?branch=master)](https://travis-ci.org/Oscil8/faraday-zipkin)
+[![Build Status](https://travis-ci.org/openzipkin/faraday-zipkin.svg?branch=master)](https://travis-ci.org/openzipkin/faraday-zipkin)
 
 Faraday middleware to generate Zipkin tracing headers.
 
@@ -24,7 +24,7 @@ Include Faraday::Zipkin::TraceHeaders as a Faraday middleware:
 
     require 'faraday'
     require 'faraday-zipkin'
-    
+
     conn = Faraday.new(:url => 'http://localhost:9292/') do |faraday|
       # 'service_name' is optional (but recommended)
       faraday.use Faraday::Zipkin::TraceHeaders, 'service_name'
@@ -40,7 +40,7 @@ first section of the destination URL (e.g. 'service.example.com' =>
 
 ## Contributing
 
-1. Fork it ( https://github.com/Oscil8/faraday-zipkin/fork )
+1. Fork it ( https://github.com/openzipkin/faraday-zipkin/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/faraday-zipkin.gemspec
+++ b/faraday-zipkin.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", ">= 0.8"
   spec.add_dependency "thrift", "~> 0.9.0"
-  spec.add_dependency "finagle-thrift", "~> 1.3.1"
+  spec.add_dependency "finagle-thrift", "~> 1.4"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/faraday-zipkin.gemspec
+++ b/faraday-zipkin.gemspec
@@ -6,11 +6,11 @@ require 'faraday-zipkin/version'
 Gem::Specification.new do |spec|
   spec.name          = "faraday-zipkin"
   spec.version       = Faraday::Zipkin::VERSION
-  spec.authors       = ["Ariel Salomon"]
-  spec.email         = ["asalomon@lookout.com"]
+  spec.authors       = ["James Way, Ariel Salomon"]
+  spec.email         = ["james.way@lookout.com"]
   spec.summary       = %q{Faraday middleware to generate Zipkin tracing headers.}
   spec.description   = %q{Faraday middleware to generate Zipkin tracing headers.}
-  spec.homepage      = "https://github.com/Oscil8/faraday-zipkin"
+  spec.homepage      = "https://github.com/openzipkin/faraday-zipkin"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")

--- a/lib/faraday-zipkin/version.rb
+++ b/lib/faraday-zipkin/version.rb
@@ -1,5 +1,5 @@
 module Faraday
   module Zipkin
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end


### PR DESCRIPTION
- bumps finagle-thrift version to 1.4.1 which solves some [concurrency issues](https://github.com/twitter/finagle/pull/363)
- removes references to Oscil8, which was the previous home of the repo.  
- Preserving Ariel as contributor, adding James' email
